### PR TITLE
Update import.md

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -194,7 +194,7 @@ If you have any tests ot fixtures that should be ignored, please set the `exclus
 
 ## 3. Download & run
 
-Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos import --file=path/to/imported-targets.json`
+Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos import --file=path/to/import-projects.json`
 
 ## 4. Review logs
 When import is started via Snyk API, many files & targets will be added to an import job. This job when complete will provide logs of what projects could be detected, which failed and any errors that were encountered. For more details see [Import API documentation](https://snyk.docs.apiary.io/#reference/import-projects/import/import-targets)


### PR DESCRIPTION
Changed imported-targets.json to import-projects.json because naming was not consistent across the document.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

I changed imported-targets.json to import-projects.json because naming was not consistent across the document.

### Notes for the reviewer

This is not a functional change.

### More information

- [Link to documentation]()

### Screenshots

_Visuals that may help the reviewer_
