### PR TITLE
chore: do not os security scan test files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
           release-branch: master # TODO: remove when master branch is renamed
           iac-scan: disabled
           open-source-scan: critical # TODO: remove this once Axios vulns are fixed
+          open-source-additional-arguments: --exclude=test
 
   build-test-monitor:
     <<: *defaults


### PR DESCRIPTION
exclude test folder from open source scanning