### PR TITLE
fix: override vulnerable axios version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
     "typescript": "4.5",
     "uuid": "9.0.0"
   },
+  "overrides": {
+    "snyk-request-manager": {
+      "axios": "1.7.4"
+    }
+  },
   "pkg": {
     "scripts": [
       "dist/**/*.js"


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does

Overrides vulnerable Axios version from `snyk-request-manager`.

Motivation for overriding `axios` instead of using later versions of the direct dependency is a breaking change introduced in `snyk-request-manager` 1.8.5 which enforces `api[.env].snyk.io` URLs, potentially causing customer configurations to stop working. Any existing users that supply `SNYK_API` env vars with the old `[env.][app.]snyk.io/api` format would start seeing errors and failures.

As the Axios vuln needs addressing ASAP and a complete API URL handling fix would take significant time, an override is called for.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Link to documentation]()

### Screenshots

_Visuals that may help the reviewer_
