### PR TITLE
fix: ignore disabled azure repos from listing

### DIFF
--- a/src/lib/source-handlers/azure/list-repos.ts
+++ b/src/lib/source-handlers/azure/list-repos.ts
@@ -15,6 +15,7 @@ interface AzureReposResponse {
     name: string;
     project: { name: string };
     defaultBranch: string;
+    isDisabled: boolean;
   }[];
 }
 export async function fetchAllRepos(
@@ -61,9 +62,8 @@ async function getRepos(
     Response body: ${JSON.stringify(body)}`);
   }
   const { value: repos } = body;
-  repos.map((repo) => {
-    const { name, project, defaultBranch } = repo;
-    if (name && project && project.name && defaultBranch) {
+  repos.map(({ name, project, defaultBranch, isDisabled }) => {
+    if (name && project && project.name && defaultBranch && !isDisabled) {
       repoList.push({
         name,
         owner: project.name,

--- a/test/lib/fixtures/azure/org-repos.json
+++ b/test/lib/fixtures/azure/org-repos.json
@@ -58,7 +58,7 @@
       "remoteUrl": "https://dev.azure.com/remoteUrl",
       "sshUrl": "",
       "webUrl": "https://dev.azure.com/remoteUrl",
-      "isDisabled": false
+      "isDisabled": true
     }
   ],
   "count": 3

--- a/test/lib/source-handlers/azure/azure.test.ts
+++ b/test/lib/source-handlers/azure/azure.test.ts
@@ -70,7 +70,7 @@ describe('Testing azure-devops interaction', () => {
   });
   test('Test listAzureRepos with one page', async () => {
     const repos = await listAzureRepos('reposTestOrg', 'https://azure-tests');
-    expect(repos).toHaveLength(3);
+    expect(repos).toHaveLength(2);
   });
   test('listAzureRepos to fail', async () => {
     expect(async () => {

--- a/test/system/orgs:data/gitlab.test.ts
+++ b/test/system/orgs:data/gitlab.test.ts
@@ -26,7 +26,7 @@ describe('General `snyk-api-import orgs:data <...>`', () => {
         expect(stderr).toEqual('');
         expect(err).toBeNull();
         expect(stdout).toMatch(
-          'Found 7 group(s). Written the data to file: group-hello-gitlab-orgs.json',
+          'Found 9 group(s). Written the data to file: group-hello-gitlab-orgs.json',
         );
         deleteFiles([
           path.resolve(__dirname, `group-${groupId}-gitlab-orgs.json`),


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does

Ignores disabled Azure repos from listing as they cause 404 error when attempting to import.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [#ask-import request](https://snyk.slack.com/archives/C06RJJY6Y4A/p1730318407230459)

### Screenshots

_Visuals that may help the reviewer_
