### PR TITLE
chore: Update the snyk context to new team (cs-eng).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,12 +117,12 @@ workflows:
     jobs:
       - security-scans:
           name: Security Scans
-          context: analysis_import
+          context: cs-engineers-org-tagger
 
       - prodsec/secrets-scan:
           name: Scan repository for secrets
           context: snyk-bot-slack
-          channel: snyk-on-snyk-analysis_import
+          channel: ask-cs-ops
 
   nightly:
     triggers:


### PR DESCRIPTION
### What this does

Updates the security scan context to the cs-eng team to reflect repo ownership change. The channel for secret scanning alerts was also updated. 


